### PR TITLE
Add job in CI for publishing to nuget.org

### DIFF
--- a/.github/workflows/publish-nuget-packages.yaml
+++ b/.github/workflows/publish-nuget-packages.yaml
@@ -72,7 +72,7 @@ jobs:
             dotnet-version: ${{ env.DOTNET_VERSION }}
 
     Publish-Production:
-      name: Publish production package
+      name: Publish production package to GitHub/MaerskTech
       environment:
         name: Production - Nuget
       runs-on: ubuntu-latest
@@ -86,4 +86,22 @@ jobs:
           with:
             package-path: nugetPackage\*.nupkg
             token: ${{ secrets.GITHUB_TOKEN }}
+            dotnet-version: ${{ env.DOTNET_VERSION }}
+
+    Publish-NugetDotOrg:
+      name: Publish production package to nuget.org
+      environment:
+        name: Production - Nuget.org
+      runs-on: ubuntu-latest
+      needs: Build
+      if: ${{ success() && github.ref == 'refs/heads/main' }}
+      steps:
+        - uses: actions/checkout@v3
+
+        - name: Publish NuGet package
+          uses: ./.github/actions/publish-nuget
+          with:
+            package-source: https://api.nuget.org/v3/index.json
+            package-path: nugetPackage\*.nupkg
+            token: ${{ secrets.NUGET_ORG_TOKEN }}
             dotnet-version: ${{ env.DOTNET_VERSION }}


### PR DESCRIPTION
The secret for publishing to nuget.org is already added to environment secrets.