### PR TITLE
Added handling of DateOnly

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,7 +6,7 @@
     <CodeAnalysisRuleSet>..\..\maersk.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/Maersk.Test.AutoFixtureExtensions/AutoDataWithCustomizationAttribute.cs
+++ b/src/Maersk.Test.AutoFixtureExtensions/AutoDataWithCustomizationAttribute.cs
@@ -25,7 +25,11 @@ public sealed class AutoDataWithCustomizationAttribute : AutoDataAttribute
                     customizations.Select(customization =>
                         CustomizationBuilder.CreateCustomization(customization)));
 
-                return new Fixture().Customize(composite);
+                var fixture = new Fixture().Customize(composite);
+
+                fixture.Customize<DateOnly>(c => c.FromFactory<DateTime>(DateOnly.FromDateTime));
+
+                return fixture;
             })
     {
     }

--- a/src/Maersk.Test.AutoFixtureExtensions/Maersk.Test.AutoFixtureExtensions.csproj
+++ b/src/Maersk.Test.AutoFixtureExtensions/Maersk.Test.AutoFixtureExtensions.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <VersionPrefix>1.2.0</VersionPrefix>
+    <VersionPrefix>1.2.1</VersionPrefix>
     <Authors>Service Delivery</Authors>
     <Company>A.P. Møller - Mærsk</Company>
     <PackageProjectUrl>https://github.com/MaerskTech/maersk-test-autofixture-extensions</PackageProjectUrl>
@@ -23,10 +23,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.17.0" />
-    <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
-    <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
-    <PackageReference Include="AutoMapper" Version="11.0.1" />
-    <PackageReference Include="Castle.Core" Version="4.4.1" />
+    <PackageReference Include="AutoFixture" Version="4.18.0" />
+    <PackageReference Include="AutoFixture.AutoMoq" Version="4.18.0" />
+    <PackageReference Include="AutoFixture.Xunit2" Version="4.18.0" />
+    <PackageReference Include="AutoMapper" Version="12.0.1" />
+    <PackageReference Include="Castle.Core" Version="5.1.1" />
   </ItemGroup>
 </Project>

--- a/src/Maersk.Test.AutoFixtureExtensions/Maersk.Test.AutoFixtureExtensions.csproj
+++ b/src/Maersk.Test.AutoFixtureExtensions/Maersk.Test.AutoFixtureExtensions.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <VersionPrefix>1.2.1</VersionPrefix>
+    <VersionPrefix>1.3.0</VersionPrefix>
     <Authors>Service Delivery</Authors>
     <Company>A.P. Møller - Mærsk</Company>
     <PackageProjectUrl>https://github.com/MaerskTech/maersk-test-autofixture-extensions</PackageProjectUrl>

--- a/src/Maersk.Test.AutoFixtureExtensions/Maersk.Test.AutoFixtureExtensions.csproj
+++ b/src/Maersk.Test.AutoFixtureExtensions/Maersk.Test.AutoFixtureExtensions.csproj
@@ -29,4 +29,8 @@
     <PackageReference Include="AutoMapper" Version="12.0.1" />
     <PackageReference Include="Castle.Core" Version="5.1.1" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.406" />
+  </ItemGroup>
 </Project>

--- a/src/Maersk.Test.AutoFixtureExtensions/Maersk.Test.AutoFixtureExtensions.csproj
+++ b/src/Maersk.Test.AutoFixtureExtensions/Maersk.Test.AutoFixtureExtensions.csproj
@@ -29,8 +29,4 @@
     <PackageReference Include="AutoMapper" Version="12.0.1" />
     <PackageReference Include="Castle.Core" Version="5.1.1" />
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.406" />
-  </ItemGroup>
 </Project>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.406">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Maersk.Test.AutoFixtureExtensions.Tests/Maersk.Test.AutoFixtureExtensions.Tests.csproj
+++ b/test/Maersk.Test.AutoFixtureExtensions.Tests/Maersk.Test.AutoFixtureExtensions.Tests.csproj
@@ -6,18 +6,18 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AutoFixture" Version="4.17.0" />
-		<PackageReference Include="Moq" Version="4.17.2" />
-		<PackageReference Include="AutoFixture.Idioms" Version="4.17.0" />
-		<PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
-		<PackageReference Include="FluentAssertions" Version="6.6.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-		<PackageReference Include="xunit" Version="2.4.1" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+		<PackageReference Include="AutoFixture" Version="4.18.0" />
+		<PackageReference Include="Moq" Version="4.20.69" />
+		<PackageReference Include="AutoFixture.Idioms" Version="4.18.0" />
+		<PackageReference Include="AutoFixture.Xunit2" Version="4.18.0" />
+		<PackageReference Include="FluentAssertions" Version="6.12.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+		<PackageReference Include="xunit" Version="2.5.0" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="3.1.2">
+		<PackageReference Include="coverlet.collector" Version="6.0.0">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>


### PR DESCRIPTION
# What
- In `AutoDataWithCustomizationAttribute` added a factory to create `DateOnly`

# Why
- Currently AutoFixture doesn't support generation of the `DateOnly` type, as per [this link](https://stackoverflow.com/questions/73732174/does-autofixture-support-dateonly-for-net6)